### PR TITLE
Correctly setting the variable abandoned_to_quality

### DIFF
--- a/example/mmsys18/sabre-mmsys18.py
+++ b/example/mmsys18/sabre-mmsys18.py
@@ -1348,7 +1348,7 @@ if __name__ == '__main__':
         else:
             (quality, delay) = (abandoned_to_quality, 0)
             replace = None
-            abandon_to_quality = None
+            abandoned_to_quality = None
 
         if replace != None:
             delay = 0
@@ -1419,7 +1419,7 @@ if __name__ == '__main__':
                 buffer_contents += [quality]
                 next_segment += 1
             else:
-                abandon_to_quality = download_metric.abandon_to_quality
+                abandoned_to_quality = download_metric.abandon_to_quality
         else:
             # abandon_to_quality == None
             if download_metric.abandon_to_quality == None:

--- a/example/tomm19/sabre-tomm19.py
+++ b/example/tomm19/sabre-tomm19.py
@@ -1348,7 +1348,7 @@ if __name__ == '__main__':
         else:
             (quality, delay) = (abandoned_to_quality, 0)
             replace = None
-            abandon_to_quality = None
+            abandoned_to_quality = None
 
         if replace != None:
             delay = 0
@@ -1419,7 +1419,7 @@ if __name__ == '__main__':
                 buffer_contents += [quality]
                 next_segment += 1
             else:
-                abandon_to_quality = download_metric.abandon_to_quality
+                abandoned_to_quality = download_metric.abandon_to_quality
         else:
             # abandon_to_quality == None
             if download_metric.abandon_to_quality == None:

--- a/src/sabre.py
+++ b/src/sabre.py
@@ -1414,7 +1414,7 @@ if __name__ == '__main__':
         else:
             (quality, delay) = (abandoned_to_quality, 0)
             replace = None
-            abandon_to_quality = None
+            abandoned_to_quality = None
 
         if replace != None:
             delay = 0
@@ -1485,7 +1485,7 @@ if __name__ == '__main__':
                 buffer_contents += [quality]
                 next_segment += 1
             else:
-                abandon_to_quality = download_metric.abandon_to_quality
+                abandoned_to_quality = download_metric.abandon_to_quality
         else:
             # abandon_to_quality == None
             if download_metric.abandon_to_quality == None:


### PR DESCRIPTION
The abandoned_to_quality variable is used to abandon the segment of current quality, but it has not been assigned a value. It is suspected that there may have been a spelling error during assignment, where it was mistakenly spelled as abandon_to_qulity.